### PR TITLE
[RFC] GA4 add Lookback windows parameter

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-v4/source_google_analytics_v4/source.py
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/source_google_analytics_v4/source.py
@@ -102,6 +102,7 @@ class GoogleAnalyticsV4Stream(HttpStream, ABC):
     def __init__(self, config: MutableMapping):
         super().__init__(authenticator=config["authenticator"])
         self.start_date = config["start_date"]
+        self.lookback_window = config["lookback_window"]
         self.window_in_days: int = config.get("window_in_days", 1)
         self.view_id = config["view_id"]
         self.metrics = config["metrics"]
@@ -260,10 +261,10 @@ class GoogleAnalyticsV4Stream(HttpStream, ABC):
         if stream_state:
             prev_end_date = pendulum.parse(stream_state.get(self.cursor_field)).date()
             start_date = prev_end_date.add(days=1)  # do not include previous `end_date`
-        # always resync 2 previous days to be sure data is golden
+        # always resync lookback_window previous days to be sure data is golden
         # https://support.google.com/analytics/answer/1070983?hl=en#DataProcessingLatency&zippy=%2Cin-this-article
         # https://github.com/airbytehq/airbyte/issues/12013#issuecomment-1111255503
-        start_date = start_date.subtract(days=2)
+        start_date = start_date.subtract(days=self.lookback_window)
 
         date_slices = []
         slice_start_date = start_date

--- a/airbyte-integrations/connectors/source-google-analytics-v4/source_google_analytics_v4/spec.json
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/source_google_analytics_v4/spec.json
@@ -102,6 +102,14 @@
         "examples": [30, 60, 90, 120, 200, 364],
         "default": 1,
         "order": 4
+      },
+      "lookback_window": {
+        "type": "integer",
+        "title": "Days in the past that we should refresh data",
+        "description": "Since Google Analytics has a data processing latency, we should specify how many days in the past we should refresh the data",
+        "examples": [2,3,4,7,28],
+        "default": 2,
+        "order": 5
       }
     }
   },


### PR DESCRIPTION
## What
Right now the lookback window is hardcoded to 2 days. This can cause some issues when the account has a different timezone configured.

## How
We added the parameter lookback window to the configuration, so we can test different windows to ensure having up-to-date data always.