### PR TITLE
GA4 Lookback Window

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/source.py
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/source.py
@@ -216,6 +216,12 @@ class GoogleAnalyticsDataApiBaseStream(GoogleAnalyticsDataApiAbstractStream):
         start_date = stream_state and stream_state.get(self.cursor_field)
         if start_date:
             start_date = utils.string_to_date(start_date, self._record_date_format, old_format=DATE_FORMAT)
+
+            # Using a lookback window to have issues with the attribution delay
+            lookback_window = self.config.get("lookback_window")
+            if lookback_window:
+                start_date = start_date - datetime.timedelta(days=self.config["lookback_window"])
+                
             start_date = max(start_date, self.config["date_ranges_start_date"])
         else:
             start_date = self.config["date_ranges_start_date"]

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/spec.json
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/spec.json
@@ -104,6 +104,14 @@
         "maximum": 364,
         "default": 1,
         "order": 4
+      },
+      "lookback_window": {
+        "type": "integer",
+        "title": "Days in the past that we should refresh data",
+        "description": "Since Google Analytics has a data processing latency, we should specify how many days in the past we should refresh the data",
+        "examples": [2,3,4,7,28],
+        "default": 0,
+        "order": 5
       }
     }
   },


### PR DESCRIPTION
## What
Right now there is no lookback window. This can cause some issues with the delay in attribution that some networks like Facebook can have.

## How
We added the parameter lookback window to the configuration, so we can test different windows to ensure having up-to-date data always.